### PR TITLE
Warning when Librato will truncate source key

### DIFF
--- a/lib/fluent/plugin/out_librato.rb
+++ b/lib/fluent/plugin/out_librato.rb
@@ -35,6 +35,11 @@ module Fluent
           log.warn "missing the required field(s) " + missing_keys.join(",")
           next
         end
+
+        if record[@source_key].length > 63
+          log.warn "source key is longer than 63 characters and will be truncated in Librato."
+        end
+
         @queue.add(
           record[@measurement_key].to_s =>
             {


### PR DESCRIPTION
This is a limitation in Librato, thought it should be passed as a warning as it was failing silently for me.