### PR TITLE
Add field verifications and generate relevant log warning/errors

### DIFF
--- a/fluent-plugin-librato.gemspec
+++ b/fluent-plugin-librato.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "test_unit"
+
   spec.add_runtime_dependency "fluentd"
   spec.add_runtime_dependency "librato-metrics"
 end

--- a/fluent-plugin-librato.gemspec
+++ b/fluent-plugin-librato.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "test_unit"
+  spec.add_development_dependency "test-unit"
 
   spec.add_runtime_dependency "fluentd"
   spec.add_runtime_dependency "librato-metrics"

--- a/lib/fluent/plugin/out_librato.rb
+++ b/lib/fluent/plugin/out_librato.rb
@@ -33,19 +33,19 @@ module Fluent
 
     def validate_fields(record)
       if record[@source_key].length > 63
-          log.warn "Source value is longer than 63 characters and will be truncated in Librato."
+          log.warn "Source value is longer than 63 characters and will be truncated in Librato"
       end
 
       if invalid_characters? record[@source_key]
-          log.error "Source value may only contain characters 'A-Za-z0-9.:-_'."
+          log.error "Source value may only contain characters 'A-Za-z0-9.:-_'"
       end
 
       if record[@measurement_key].length > 63
-          log.warn "Measurement value is longer than 63 characters and will be truncated in Librato."
+          log.warn "Measurement value is longer than 63 characters and will be truncated in Librato"
       end
 
       if invalid_characters? record[@measurement_key]
-          log.error "Measurement value may only contain characters 'A-Za-z0-9.:-_'."
+          log.error "Measurement value may only contain characters 'A-Za-z0-9.:-_'"
       end
     end
 

--- a/test/fluent/plugin/out_librato_test.rb
+++ b/test/fluent/plugin/out_librato_test.rb
@@ -8,47 +8,45 @@ class LibratoOutputTest < Test::Unit::TestCase
     apikey this_is_an_api_key
   ]
 
+  def create_driver(conf)
+    d = Fluent::Test::BufferedOutputTestDriver.new(Fluent::LibratoOutput, @tag).configure(conf)
+    return d.instance, d.instance.log.out.logs
+  end
+
   setup do
     Fluent::Test.setup
     @tag = 'test'
     @time = Fluent::Engine.now
-  end
-
-  def create_driver(conf)
-    Fluent::Test::BufferedOutputTestDriver.new(Fluent::LibratoOutput, @tag).configure(conf)
+    @instance, @logs = create_driver(CONFIG)
   end
 
   def test_source_length_warning
-    d = create_driver(CONFIG)
-    d.instance.validate_fields({'source' => 'b' * 64, 'key' => 'valid_key'})
+    @instance.validate_fields({'source' => 'b' * 64, 'key' => 'valid_key'})
 
-    assert_equal 1, d.instance.log.out.logs.length
-    assert_match /\[warn\]: Source value is longer than 63 characters and will be truncated in Librato/, d.instance.log.out.logs[0]
+    assert_equal 1, @logs.length
+    assert_match /\[warn\]: Source value is longer than 63 characters and will be truncated in Librato/, @logs.first
   end 
 
   def test_source_invalid_character_warning
-    d = create_driver(CONFIG)
-    d.instance.validate_fields({'source' => 'invalid\source', 'key' => 'valid_key'})
+    @instance.validate_fields({'source' => 'invalid\source', 'key' => 'valid_key'})
 
-    assert_equal 1, d.instance.log.out.logs.length
-    assert_match /\[error\]: Source value may only contain characters 'A-Za-z0-9.:-_'/, d.instance.log.out.logs[0]
+    assert_equal 1, @logs.length
+    assert_match /\[error\]: Source value may only contain characters 'A-Za-z0-9.:-_'/, @logs.first
   end 
 
 
   def test_measurement_length_warning
-    d = create_driver(CONFIG)
-    d.instance.validate_fields({'source' => 'valid_source', 'key' => 'b' * 64})
+    @instance.validate_fields({'source' => 'valid_source', 'key' => 'b' * 64})
 
-    assert_equal 1, d.instance.log.out.logs.length
-    assert_match /\[warn\]: Measurement value is longer than 63 characters and will be truncated in Librato/, d.instance.log.out.logs[0]
+    assert_equal 1, @logs.length
+    assert_match /\[warn\]: Measurement value is longer than 63 characters and will be truncated in Librato/, @logs.first
   end
 
   def test_measurement_invalid_character_warning
-    d = create_driver(CONFIG)
-    d.instance.validate_fields({'source' => 'valid_source', 'key' => 'invalid\key'})
+    @instance.validate_fields({'source' => 'valid_source', 'key' => 'invalid\key'})
 
-    assert_equal 1, d.instance.log.out.logs.length
-    assert_match /\[error\]: Measurement value may only contain characters 'A-Za-z0-9.:-_'/, d.instance.log.out.logs[0]
+    assert_equal 1, @logs.length
+    assert_match /\[error\]: Measurement value may only contain characters 'A-Za-z0-9.:-_'/, @logs.first
   end 
 
 end

--- a/test/fluent/plugin/out_librato_test.rb
+++ b/test/fluent/plugin/out_librato_test.rb
@@ -1,0 +1,54 @@
+require 'fluent/test'
+require_relative '../../../lib/fluent/plugin/out_librato'
+
+class LibratoOutputTest < Test::Unit::TestCase
+
+  CONFIG = %[
+    email fake@email.com
+    apikey this_is_an_api_key
+  ]
+
+  setup do
+    Fluent::Test.setup
+    @tag = 'test'
+    @time = Fluent::Engine.now
+  end
+
+  def create_driver(conf)
+    Fluent::Test::BufferedOutputTestDriver.new(Fluent::LibratoOutput, @tag).configure(conf)
+  end
+
+  def test_source_length_warning
+    d = create_driver(CONFIG)
+    d.instance.validate_fields({'source' => 'b' * 64, 'key' => 'valid_key'})
+
+    assert_equal 1, d.instance.log.out.logs.length
+    assert_match /\[warn\]: Source value is longer than 63 characters and will be truncated in Librato/, d.instance.log.out.logs[0]
+  end 
+
+  def test_source_invalid_character_warning
+    d = create_driver(CONFIG)
+    d.instance.validate_fields({'source' => 'invalid\source', 'key' => 'valid_key'})
+
+    assert_equal 1, d.instance.log.out.logs.length
+    assert_match /\[error\]: Source value may only contain characters 'A-Za-z0-9.:-_'/, d.instance.log.out.logs[0]
+  end 
+
+
+  def test_measurement_length_warning
+    d = create_driver(CONFIG)
+    d.instance.validate_fields({'source' => 'valid_source', 'key' => 'b' * 64})
+
+    assert_equal 1, d.instance.log.out.logs.length
+    assert_match /\[warn\]: Measurement value is longer than 63 characters and will be truncated in Librato/, d.instance.log.out.logs[0]
+  end
+
+  def test_measurement_invalid_character_warning
+    d = create_driver(CONFIG)
+    d.instance.validate_fields({'source' => 'valid_source', 'key' => 'invalid\key'})
+
+    assert_equal 1, d.instance.log.out.logs.length
+    assert_match /\[error\]: Measurement value may only contain characters 'A-Za-z0-9.:-_'/, d.instance.log.out.logs[0]
+  end 
+
+end


### PR DESCRIPTION
This pull request adds validation to the fields that are to be passed to librato as per the spec found at http://dev.librato.com/v1/metrics. The tests can be run by executing
```
ruby test/fluent/plugin/out_librato_test.rb
```